### PR TITLE
Improve installation instructions

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,3 @@
+S .
+B _build
+PKG lwt

--- a/test-mirage
+++ b/test-mirage
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+DEV_SIDE_BINARY=$(dirname $0)/_build/dev.native
+# DEV_SIDE_BINARY=/path/to/_build/dev.native
+if [ ! -f $DEV_SIDE_BINARY ]; then
+  echo "$DEV_SIDE_BINARY not found (try running 'make')"
+  exit 1
+fi
+exec qrexec-client-vm dom0 talex5.TestMirage $DEV_SIDE_BINARY "$@"


### PR DESCRIPTION
Update README:
- More details on how to create the AppVM.
- Show how to build the tools.
- Show how to copy the dom0 binary to dom0.
- Show how to create the policy files.
- Explain what the policy means.
- Remove out-of-date information about functoria.
- Mention about the new `-t qubes` feature of Mirage 3.

Add a `test-mirage` script that works out of the box.